### PR TITLE
use 'application/octet-stream' as default Content-Type for resource (…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "warcio",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "main": "index.js",
   "module": "main.js",
   "license": "Apache-2.0",

--- a/src/warcrecord.js
+++ b/src/warcrecord.js
@@ -71,8 +71,8 @@ class WARCRecord extends BaseAsyncIterReader
       warcHeaders.headers.set("WARC-Record-ID", `<urn:uuid:${uuid()}>`);
     }
 
-    if (!warcHeaders.headers.get("Content-Type") && defaultRecordCT[type]) {
-      warcHeaders.headers.set("Content-Type", defaultRecordCT[type]);
+    if (!warcHeaders.headers.get("Content-Type")) {
+      warcHeaders.headers.set("Content-Type", defaultRecordCT[type] || "application/octet-stream");
     }
 
     if (!reader) {

--- a/test/testSerializer.js
+++ b/test/testSerializer.js
@@ -126,6 +126,26 @@ test('test auto record id, current date', async t => {
 
 });
 
+test('test default content-type for resource', async t => {
+  async function* payload() {
+    yield encoder.encode('some text');
+  }
+
+  const url = "urn:custom:http://example.com/";
+  const type = "resource";
+  const warcHeaders = {};
+
+  const record = await WARCRecord.create({url, type, warcHeaders}, payload());
+
+  t.is(record.warcContentType, "application/octet-stream");
+  t.not(record.warcDate, null);
+  t.not(record.warcHeader("WARC-Record-ID", null));
+  t.not(record.warcPayloadDigest, null);
+  t.is(record.warcPayloadDigest, record.warcBlockDigest);
+
+});
+
+
 
 const createRecordGzipped = async (t) => {
 


### PR DESCRIPTION
…and other records) if no warc content-type is specified

addresses issue discussed in #22