### PR TITLE
Standardize POST canonicalization query strings with pywb

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "warcio",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "warcio",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "base32-encode": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "warcio",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "warcio",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "base32-encode": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "warcio",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "keywords": [
     "WARC",
     "web archiving"

--- a/test/testUtils.test.ts
+++ b/test/testUtils.test.ts
@@ -34,6 +34,22 @@ describe("utils", () => {
     ).toBe("abc=def&data=bar&bar=2&a=3&a.2_=4&bar.2_=123&a.3_=5");
   });
 
+  test("another json with more complicated data", () => {
+    expect(
+      toQuery({
+       "type": "event",
+       "id": 44.0,
+       "float": 35.7,
+       "values": [true, false, null],
+       "source": {
+          "type": "component",
+          "id": "a+b&c= d",
+          "values": [3, 4]
+       }
+      })
+    ).toBe("type=event&id=44&float=35.7&values=true&values.2_=false&values.3_=null&type.2_=component&id.2_=a%2Bb%26c%3D+d&values.4_=3&values.5_=4");
+  });
+
   test("post-to-get empty", () => {
     const request = {
       postData: "",


### PR DESCRIPTION
Fixes #58 

This PR modifies canonicalization of non-GET request bodies into query strings to be consistent across Webrecorder projects. It introduces a new test case that is also in pywb to help ensure parity.

This is part of a cross-repo effort to standardize how POST canonicalization works in Webrecorder tools, and document this in a Webrecorder specfiication.

## Todo

Still needs testing against fuzzy matching to ensure that there aren't unintended side effects to the change.

