### PR TITLE
cdxj compatibility:

### DIFF
--- a/src/lib/indexer.ts
+++ b/src/lib/indexer.ts
@@ -335,7 +335,15 @@ export class CDXIndexer extends Indexer {
     delete result["urlkey"];
     delete result["timestamp"];
 
-    return `${urlkey} ${timestamp} ${JSON.stringify(result)}\n`;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const replacer = (key: string, value: any) : any => {
+      if (["offset", "length", "status"].includes(key)) {
+        return value === null || value === undefined ? "" : "" + value;
+      }
+      return value;
+    }
+
+    return `${urlkey} ${timestamp} ${JSON.stringify(result, replacer)}\n`;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -375,7 +383,7 @@ export class CDXIndexer extends Indexer {
             break;
 
           default:
-            field = "content-type";
+            return record.warcContentType;
         }
         value = super.getField(field, record);
         return value ? value.toString().split(";", 1)[0]?.trim() : null;

--- a/test/testIndexer.test.ts
+++ b/test/testIndexer.test.ts
@@ -84,8 +84,8 @@ describe("indexer", () => {
     await index(
       ["cdx-index", get_warc_path("data/example.warc.gz")],
       `\
-com,example)/ 20170306040206 {"url":"http://example.com/","mime":"text/html","status":200,"digest":"G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK","length":1228,"offset":784,"filename":"example.warc.gz"}
-com,example)/ 20170306040348 {"url":"http://example.com/","mime":"warc/revisit","status":200,"digest":"G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK","length":586,"offset":2621,"filename":"example.warc.gz"}
+com,example)/ 20170306040206 {"url":"http://example.com/","mime":"text/html","status":"200","digest":"G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK","length":"1228","offset":"784","filename":"example.warc.gz"}
+com,example)/ 20170306040348 {"url":"http://example.com/","mime":"warc/revisit","status":"200","digest":"G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK","length":"586","offset":"2621","filename":"example.warc.gz"}
 `,
     );
   });
@@ -156,9 +156,9 @@ com,example)/ 20170306040348 http://example.com/ warc/revisit 200 G7HRM7BGOKSKMS
     await index(
       ["cdx-index", get_warc_path("data/post-test.warc.gz")],
       `\
-org,httpbin)/post?__wb_method=post&foo=bar&test=abc 20140610000859 {"url":"http://httpbin.org/post","mime":"application/json","status":200,"digest":"M532K5WS4GY2H4OVZO6HRPOP47A7KDWU","length":720,"offset":0,"filename":"post-test.warc.gz","method":"POST","requestBody":"foo=bar&test=abc"}
-org,httpbin)/post?__wb_method=post&a=1&b=%5B%5D&c=3 20140610001151 {"url":"http://httpbin.org/post","mime":"application/json","status":200,"digest":"M7YCTM7HS3YKYQTAWQVMQSQZBNEOXGU2","length":723,"offset":1196,"filename":"post-test.warc.gz","method":"POST","requestBody":"A=1&B=[]&C=3"}
-org,httpbin)/post?__wb_method=post&data=%5E&foo=bar 20140610001255 {"url":"http://httpbin.org/post?foo=bar","mime":"application/json","status":200,"digest":"B6E5P6JUZI6UPDTNO4L2BCHMGLTNCUAJ","length":723,"offset":2395,"filename":"post-test.warc.gz","method":"POST","requestBody":"data=^"}
+org,httpbin)/post?__wb_method=post&foo=bar&test=abc 20140610000859 {"url":"http://httpbin.org/post","mime":"application/json","status":"200","digest":"M532K5WS4GY2H4OVZO6HRPOP47A7KDWU","length":"720","offset":"0","filename":"post-test.warc.gz","method":"POST","requestBody":"foo=bar&test=abc"}
+org,httpbin)/post?__wb_method=post&a=1&b=%5B%5D&c=3 20140610001151 {"url":"http://httpbin.org/post","mime":"application/json","status":"200","digest":"M7YCTM7HS3YKYQTAWQVMQSQZBNEOXGU2","length":"723","offset":"1196","filename":"post-test.warc.gz","method":"POST","requestBody":"A=1&B=[]&C=3"}
+org,httpbin)/post?__wb_method=post&data=%5E&foo=bar 20140610001255 {"url":"http://httpbin.org/post?foo=bar","mime":"application/json","status":"200","digest":"B6E5P6JUZI6UPDTNO4L2BCHMGLTNCUAJ","length":"723","offset":"2395","filename":"post-test.warc.gz","method":"POST","requestBody":"data=^"}
 `,
     );
   });
@@ -167,9 +167,9 @@ org,httpbin)/post?__wb_method=post&data=%5E&foo=bar 20140610001255 {"url":"http:
     await index(
       ["cdx-index", get_warc_path("data/post-test-more.warc")],
       `\
-org,httpbin)/post?__wb_method=post&another=more%5Edata&test=some+data 20200809195334 {"url":"https://httpbin.org/post","mime":"application/json","status":200,"digest":"7AWVEIPQMCA4KTCNDXWSZ465FITB7LSK","length":688,"offset":0,"filename":"post-test-more.warc","method":"POST","requestBody":"test=some+data&another=more%5Edata"}
-org,httpbin)/post?__wb_method=post&a=json-data 20200809195334 {"url":"https://httpbin.org/post","mime":"application/json","status":200,"digest":"BYOQWRSQFW3A5SNUBDSASHFLXGL4FNGB","length":655,"offset":1227,"filename":"post-test-more.warc","method":"POST","requestBody":"a=json-data"}
-org,httpbin)/post?__wb_method=post&__wb_post_data=na0kc29tzq0kza0ky2h1bmstzw5jb2rlza0kna0kzgf0yq0kma0kdqo%3D 20200810055049 {"url":"https://httpbin.org/post","mime":"application/json","status":200,"digest":"34LEADQD3MOBQ42FCO2WA5TUSEL5QOKP","length":628,"offset":2338,"filename":"post-test-more.warc","method":"POST","requestBody":"__wb_post_data=NA0Kc29tZQ0KZA0KY2h1bmstZW5jb2RlZA0KNA0KZGF0YQ0KMA0KDQo="}
+org,httpbin)/post?__wb_method=post&another=more%5Edata&test=some+data 20200809195334 {"url":"https://httpbin.org/post","mime":"application/json","status":"200","digest":"7AWVEIPQMCA4KTCNDXWSZ465FITB7LSK","length":"688","offset":"0","filename":"post-test-more.warc","method":"POST","requestBody":"test=some+data&another=more%5Edata"}
+org,httpbin)/post?__wb_method=post&a=json-data 20200809195334 {"url":"https://httpbin.org/post","mime":"application/json","status":"200","digest":"BYOQWRSQFW3A5SNUBDSASHFLXGL4FNGB","length":"655","offset":"1227","filename":"post-test-more.warc","method":"POST","requestBody":"a=json-data"}
+org,httpbin)/post?__wb_method=post&__wb_post_data=na0kc29tzq0kza0ky2h1bmstzw5jb2rlza0kna0kzgf0yq0kma0kdqo%3D 20200810055049 {"url":"https://httpbin.org/post","mime":"application/json","status":"200","digest":"34LEADQD3MOBQ42FCO2WA5TUSEL5QOKP","length":"628","offset":"2338","filename":"post-test-more.warc","method":"POST","requestBody":"__wb_post_data=NA0Kc29tZQ0KZA0KY2h1bmstZW5jb2RlZA0KNA0KZGF0YQ0KMA0KDQo="}
 `,
     );
   });
@@ -178,7 +178,7 @@ org,httpbin)/post?__wb_method=post&__wb_post_data=na0kc29tzq0kza0ky2h1bmstzw5jb2
     await index(
       ["cdx-index", get_warc_path("data/example-resource.warc.gz")],
       `\
-com,example,some:8080)/ 20200405201750 {"url":"http://some.example.com:8080/","mime":"text/plain","digest":"QEF4QP424P5IOPMURMAC4K6KNUTHXQW2","length":261,"offset":0,"filename":"example-resource.warc.gz"}
+com,example,some:8080)/ 20200405201750 {"url":"http://some.example.com:8080/","mime":"text/plain","digest":"QEF4QP424P5IOPMURMAC4K6KNUTHXQW2","length":"261","offset":"0","filename":"example-resource.warc.gz"}
 `,
     );
   });


### PR DESCRIPTION
- output 'status', 'offset', 'length' as strings in cdxj
- properly read 'content-type' for non-response records
- tests: update indexer tests for cdxj strings