### PR TITLE
statusandheaders: if setting a header fails on Headers object, retry with encoded header

### DIFF
--- a/src/lib/statusandheaders.ts
+++ b/src/lib/statusandheaders.ts
@@ -188,7 +188,7 @@ export class StatusAndHeadersParser {
     } catch (_e) {
       if (!noRetry) {
         // if haven't retried yet, try encoding before saving
-        this.setHeader(name, encodeURI(value), headers, true);
+        this.setHeader(name, encodeLatin1(value), headers, true);
       }
     }
   }
@@ -203,6 +203,16 @@ function splitRemainder(str: string, sep: string, limit: number) {
     newParts.push(parts.slice(limit).join(sep));
   }
   return newParts;
+}
+
+// ===========================================================================
+function encodeLatin1(value: string) {
+  const buf = new TextEncoder().encode(value);
+
+  let str = "";
+  buf.forEach((x) => (str += String.fromCharCode(x)));
+  //buf.forEach(x => str += x < 128 ? String.fromCharCode(x) : `\\x${x}`);
+  return str;
 }
 
 // ===========================================================================

--- a/src/lib/statusandheaders.ts
+++ b/src/lib/statusandheaders.ts
@@ -188,7 +188,7 @@ export class StatusAndHeadersParser {
     } catch (_e) {
       if (!noRetry) {
         // if haven't retried yet, try encoding before saving
-        this.setHeader(name, encodeURIComponent(value), headers, true);
+        this.setHeader(name, encodeURI(value), headers, true);
       }
     }
   }

--- a/test/testWARCParser.test.ts
+++ b/test/testWARCParser.test.ts
@@ -102,6 +102,28 @@ test("StatusAndHeaders test empty", async () => {
   expect(result).toBe(null);
 });
 
+test("StatusAndHeaders test non-ascii", async () => {
+  const parser = new StatusAndHeadersParser();
+  const result = await parser.parse(
+    new AsyncIterReader(
+      getReader([
+        "\
+HTTP/1.0 200 OK\r\n\
+Content-Type: ABC\r\n\
+Some: example-испытание\r\n\
+\r\n\
+Body",
+      ]),
+    ),
+    { headersClass: Headers },
+  );
+  expect(result?.toString()).toBe(`\
+HTTP/1.0 200 OK\r
+content-type: ABC\r
+some: example-%D0%B8%D1%81%D0%BF%D1%8B%D1%82%D0%B0%D0%BD%D0%B8%D0%B5\r
+`);
+});
+
 test("Load WARC Records", async () => {
   const input =
     '\

--- a/test/testWARCParser.test.ts
+++ b/test/testWARCParser.test.ts
@@ -119,7 +119,7 @@ Body",
   );
   expect(result?.toString()).toBe(`\
 HTTP/1.0 200 OK\r\n\
-content-location: https://example.com/example-%D0%B8%D1%81%D0%BF%D1%8B%D1%82%D0%B0%D0%BD%D0%B8%D0%B5\r\n\
+content-location: https://example.com/example-Ð¸Ñ\x81Ð¿Ñ\x8BÑ\x82Ð°Ð½Ð¸Ðµ\r\n\
 content-type: ABC\r\n\
 `);
 });

--- a/test/testWARCParser.test.ts
+++ b/test/testWARCParser.test.ts
@@ -110,7 +110,7 @@ test("StatusAndHeaders test non-ascii", async () => {
         "\
 HTTP/1.0 200 OK\r\n\
 Content-Type: ABC\r\n\
-Some: example-испытание\r\n\
+Content-Location: https://example.com/example-испытание\r\n\
 \r\n\
 Body",
       ]),
@@ -118,9 +118,9 @@ Body",
     { headersClass: Headers },
   );
   expect(result?.toString()).toBe(`\
-HTTP/1.0 200 OK\r
-content-type: ABC\r
-some: example-%D0%B8%D1%81%D0%BF%D1%8B%D1%82%D0%B0%D0%BD%D0%B8%D0%B5\r
+HTTP/1.0 200 OK\r\n\
+content-location: https://example.com/example-%D0%B8%D1%81%D0%BF%D1%8B%D1%82%D0%B0%D0%BD%D0%B8%D0%B5\r\n\
+content-type: ABC\r\n\
 `);
 });
 

--- a/test/testWARCParser.test.ts
+++ b/test/testWARCParser.test.ts
@@ -111,6 +111,9 @@ test("StatusAndHeaders test non-ascii", async () => {
 HTTP/1.0 200 OK\r\n\
 Content-Type: ABC\r\n\
 Content-Location: https://example.com/example-испытание\r\n\
+Other: Value\r\n\
+Metadata: Test-メタデータ\r\n\
+More: Values\r\n\
 \r\n\
 Body",
       ]),
@@ -119,8 +122,11 @@ Body",
   );
   expect(result?.toString()).toBe(`\
 HTTP/1.0 200 OK\r\n\
-content-location: https://example.com/example-Ð¸Ñ\x81Ð¿Ñ\x8BÑ\x82Ð°Ð½Ð¸Ðµ\r\n\
+content-location: https://example.com/example-испытание\r\n\
 content-type: ABC\r\n\
+metadata: Test-メタデータ\r\n\
+more: Values\r\n\
+other: Value\r\n\
 `);
 });
 


### PR DESCRIPTION
instead of skipping invalid headers:
- encode header value as latin-1 for use with Headers object
- encode back to original when serializing
fixes #81