### PR TITLE
Support for multi-value headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "warcio",
-  "version": "2.4.0-beta.2",
+  "version": "2.4.0-beta.3",
   "keywords": [
     "WARC",
     "web archiving"

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export {
   NoConcatInflator,
   StatusAndHeadersParser,
   StatusAndHeaders,
+  HeadersMultiMap,
   WARCParser,
   WARCSerializer,
   BaseSerializerBuffer,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -36,6 +36,7 @@ export {
   mfdToQueryString,
   concatChunks,
   splitChunk,
+  HeadersMultiMap,
 } from "./utils";
 
 export type {

--- a/src/lib/statusandheaders.ts
+++ b/src/lib/statusandheaders.ts
@@ -10,7 +10,7 @@ const decoder = new TextDecoder("utf-8");
 export class StatusAndHeaders {
   statusline: string;
   headers: HeadersMultiMap | Headers;
-  private readonly reencodeHeaders?: Set<string>;
+  readonly reencodeHeaders?: Set<string>;
 
   constructor({
     statusline,

--- a/src/lib/statusandheaders.ts
+++ b/src/lib/statusandheaders.ts
@@ -1,4 +1,4 @@
-import { concatChunks, splitChunk } from "./utils";
+import { concatChunks, HeadersMultiMap, splitChunk } from "./utils";
 import { type AsyncIterReader } from "./readers";
 
 export const CRLF = new Uint8Array([13, 10]);
@@ -9,16 +9,16 @@ const decoder = new TextDecoder("utf-8");
 // ===========================================================================
 export class StatusAndHeaders {
   statusline: string;
-  headers: Map<string, string> | Headers;
-  private readonly reencodeHeaders;
+  headers: HeadersMultiMap | Headers;
+  private readonly reencodeHeaders?: Set<string>;
 
   constructor({
     statusline,
     headers,
-    reencodeHeaders
+    reencodeHeaders,
   }: {
     statusline: string;
-    headers: Map<string, string> | Headers;
+    headers: HeadersMultiMap | Headers;
     reencodeHeaders?: Set<string>;
   }) {
     this.statusline = statusline;
@@ -116,8 +116,11 @@ export class StatusAndHeadersParser {
     {
       headersClass,
       firstLine,
-    }: { firstLine?: string; headersClass: typeof Map | typeof Headers } = {
-      headersClass: Map,
+    }: {
+      firstLine?: string;
+      headersClass: typeof HeadersMultiMap | typeof Headers;
+    } = {
+      headersClass: HeadersMultiMap,
     },
   ) {
     const fullStatusLine = firstLine ? firstLine : await reader.readline();
@@ -163,7 +166,6 @@ export class StatusAndHeadersParser {
           value = headerBuff
             .slice(valueStart, valueEnd < 0 ? undefined : valueEnd)
             .trim();
-
         } else {
           value = null;
         }
@@ -183,26 +185,20 @@ export class StatusAndHeadersParser {
     return new StatusAndHeaders({
       statusline,
       headers,
-      reencodeHeaders: this.reencodeHeaders
+      reencodeHeaders: this.reencodeHeaders,
     });
   }
 
   setHeader(
     name: string,
     value: string,
-    headers: Headers | Map<string, string>,
+    headers: Headers | HeadersMultiMap,
     reencoded = false,
   ) {
     try {
-      const isHeaders = headers instanceof Headers;
-      const nameLower = name.toLowerCase();
-      if (isHeaders && nameLower === "set-cookie") {
-        headers.append(name, value);
-      } else {
-        headers.set(name, value);
-      }
-      if (isHeaders && reencoded) {
-        this.reencodeHeaders.add(nameLower);
+      headers.append(name, value);
+      if (headers instanceof Headers && reencoded) {
+        this.reencodeHeaders.add(name.toLowerCase());
       }
     } catch (_e) {
       if (!reencoded) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -293,6 +293,8 @@ export function splitChunk(
 // headers multi map
 const MULTI_VALUE_ALLOWED = ["set-cookie", "warc-concurrent-to"];
 
+// using something other than comma to reduce change of any collisions with actual data
+// in theory, collision still possible with arbitrary cookie value
 const JOIN_MARKER = ",,,";
 
 export class HeadersMultiMap extends Map<string, string> {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -288,3 +288,59 @@ export function splitChunk(
 ): [Uint8Array, Uint8Array] {
   return [chunk.slice(0, inx), chunk.slice(inx)];
 }
+
+// ===========================================================================
+// headers multi map
+const MULTI_VALUE_ALLOWED = ["set-cookie", "warc-concurrent-to"];
+
+const JOIN_MARKER = ",,,";
+
+export class HeadersMultiMap extends Map<string, string> {
+  constructor(headersInit?: HeadersInit) {
+    // if an array of array, parse that and add individually here
+    if (headersInit instanceof Array) {
+      super();
+      for (const entry of headersInit) {
+        if (entry instanceof Array) {
+          const name = entry[0];
+          const value = entry[1];
+          this.append(name, value);
+        }
+      }
+    } else {
+      super(headersInit ? Object.entries(headersInit) : undefined);
+    }
+  }
+
+  getMultiple(name: string): string[] | undefined {
+    const value = super.get(name);
+    if (!value) {
+      return undefined;
+    }
+    if (MULTI_VALUE_ALLOWED.includes(name.toLowerCase())) {
+      return value.split(JOIN_MARKER);
+    }
+    return [value];
+  }
+
+  append(name: string, value: string) {
+    if (MULTI_VALUE_ALLOWED.includes(name.toLowerCase())) {
+      const prev = this.get(name);
+      this.set(name, prev !== undefined ? prev + JOIN_MARKER + value : value);
+    } else {
+      this.set(name, value);
+    }
+  }
+
+  override *[Symbol.iterator](): IterableIterator<[string, string]> {
+    for (const [name, value] of super[Symbol.iterator]()) {
+      if (MULTI_VALUE_ALLOWED.includes(name.toLowerCase())) {
+        for (const v of value.split(JOIN_MARKER)) {
+          yield [name, v];
+        }
+      } else {
+        yield [name, value];
+      }
+    }
+  }
+}

--- a/src/lib/warcparser.ts
+++ b/src/lib/warcparser.ts
@@ -5,6 +5,7 @@ import {
 import { WARCRecord } from "./warcrecord";
 import { AsyncIterReader, LimitReader } from "./readers";
 import { type Source, type IndexerOffsetLength } from "./types";
+import { HeadersMultiMap } from "./utils";
 
 const decoder = new TextDecoder();
 const EMPTY = new Uint8Array([]);
@@ -27,7 +28,7 @@ export class WARCParser implements IndexerOffsetLength {
   _offset: number;
   _warcHeadersLength: number;
 
-  _headersClass: typeof Map | typeof Headers;
+  _headersClass: typeof HeadersMultiMap | typeof Headers;
   _parseHttp: boolean;
 
   _reader: AsyncIterReader;
@@ -41,7 +42,7 @@ export class WARCParser implements IndexerOffsetLength {
     this._offset = 0;
     this._warcHeadersLength = 0;
 
-    this._headersClass = keepHeadersCase ? Map : Headers;
+    this._headersClass = keepHeadersCase ? HeadersMultiMap : Headers;
     this._parseHttp = parseHttp;
 
     if (!(source instanceof AsyncIterReader)) {


### PR DESCRIPTION
- add new HeadersMultiMap to support set-cookie, as well as warc-concurrent-to headers with multiple values (store internally as map, convert to array for multi value headers, override iterator)
- update tests to check for multiple warc-concurrent-to
- also ensure multiple Set-Cookie works with case sensitive headers
- fixes #32
- ready to support warc-protocol from https://github.com/iipc/warc-specifications/issues/42