### PR TITLE
Add a way to purge temp buffer data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "warcio",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "keywords": [
     "WARC",
     "web archiving"

--- a/src/lib/warcserializer.ts
+++ b/src/lib/warcserializer.ts
@@ -27,6 +27,7 @@ export type WARCSerializerOpts = {
 export abstract class BaseSerializerBuffer {
   abstract write(chunk: Uint8Array): void;
   abstract readAll(): AsyncIterable<Uint8Array>;
+  abstract clear(): void;
 }
 
 // ===========================================================================
@@ -41,6 +42,10 @@ export class SerializerInMemBuffer extends BaseSerializerBuffer {
     for (const buff of this.buffers) {
       yield buff;
     }
+  }
+
+  clear() {
+    this.buffers = [];
   }
 }
 

--- a/src/lib/warcserializer.ts
+++ b/src/lib/warcserializer.ts
@@ -27,7 +27,7 @@ export type WARCSerializerOpts = {
 export abstract class BaseSerializerBuffer {
   abstract write(chunk: Uint8Array): void;
   abstract readAll(): AsyncIterable<Uint8Array>;
-  abstract clear(): void;
+  abstract purge(): void;
 }
 
 // ===========================================================================
@@ -44,7 +44,7 @@ export class SerializerInMemBuffer extends BaseSerializerBuffer {
     }
   }
 
-  clear() {
+  purge() {
     this.buffers = [];
   }
 }

--- a/src/node/warcserializer.ts
+++ b/src/node/warcserializer.ts
@@ -75,7 +75,14 @@ export class TempFileBuffer extends warcserializer.SerializerInMemBuffer {
       yield buff;
     }
 
-    await unlink(this.filename);
+    await this.deleteTempFile();
+  }
+
+  async deleteTempFile() {
+    if (this.filename) {
+      await unlink(this.filename);
+      this.filename = "";
+    }
   }
 }
 

--- a/src/node/warcserializer.ts
+++ b/src/node/warcserializer.ts
@@ -75,10 +75,10 @@ export class TempFileBuffer extends warcserializer.SerializerInMemBuffer {
       yield buff;
     }
 
-    await this.clear();
+    await this.purge();
   }
 
-  override async clear() {
+  override async purge() {
     if (this.filename) {
       await unlink(this.filename);
       this.filename = "";

--- a/src/node/warcserializer.ts
+++ b/src/node/warcserializer.ts
@@ -75,10 +75,10 @@ export class TempFileBuffer extends warcserializer.SerializerInMemBuffer {
       yield buff;
     }
 
-    await this.deleteTempFile();
+    await this.clear();
   }
 
-  async deleteTempFile() {
+  override async clear() {
     if (this.filename) {
       await unlink(this.filename);
       this.filename = "";


### PR DESCRIPTION
If serialization is being canceled, there should be a way to purge the temp buffer (clear memory / delete temp file) that is being used.
bump to 2.4.3