### PR TITLE
post-to-get canonicalization fix:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "warcio",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "keywords": [
     "WARC",
     "web archiving"

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -124,13 +124,20 @@ export function postToGetUrl(request: Request) {
   }
 
   if (query != null) {
+    request.requestBody = query;
+    try {
+      query = decodeURI(query);
+    } catch (_) {
+      // just clear out invalid query string
+      query = "";
+    }
+
     request.url = appendRequestQuery(
       request.url,
-      decodeURI(query),
+      query,
       request.method,
     );
     request.method = "GET";
-    request.requestBody = query;
     return true;
   }
 

--- a/test/testUtils.test.ts
+++ b/test/testUtils.test.ts
@@ -80,6 +80,20 @@ describe("utils", () => {
     );
   });
 
+  test("post-to-get bad query string", () => {
+    const request = {
+      postData: "a=b&c=%ac",
+      headers: new Headers({"Content-Type": "application/x-www-form-urlencoded"}),
+      method: "POST",
+      url: "https://example.com/path/file",
+    };
+    const result = postToGetUrl(request);
+    expect(result).toBe(true);
+    expect(request.url).toBe(
+      "https://example.com/path/file?__wb_method=POST&",
+    );
+  });
+
   test("surt with www", () => {
     expect(getSurt("https://www23.example.com/some/path")).toBe(
       "com,example)/some/path",


### PR DESCRIPTION
fixes webrecorder/browsertrix-crawler#796
if urlencoded query is not valid (fails decodeURI), just ignore query (set to empty string) add test

bump to 2.4.4