### PR TITLE
digestrecord include headers size fix:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "warcio",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "keywords": [
     "WARC",
     "web archiving"


### PR DESCRIPTION
follow up to #91 and #92:
- rename includeHeadersSize to returnPayloadOnlySize for clarity, default to false
- if returnPayloadOnlySize is true, still include total size in Content-Length!
- fix returning total size or payload only size on repeated calls
- tests: add tests for with and without return payload only size
- tests: add test for payloadDigestForRevisit
- bump to 2.4.7