### PR TITLE
allow any header value to be multi-valued

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "warcio",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "keywords": [
     "WARC",
     "web archiving"

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -323,9 +323,6 @@ const MULTI_VALUE_ALLOWED = [
 const JOIN_MARKER = ",,,";
 
 export function multiValueHeader(name: string, value: string[]) {
-  if (!MULTI_VALUE_ALLOWED.includes(name.toLowerCase())) {
-    throw new Error("not a valid multi value header");
-  }
   return value.join(JOIN_MARKER);
 }
 
@@ -346,21 +343,28 @@ export class HeadersMultiMap extends Map<string, string> {
     }
   }
 
+  isMultiValue(name: string, value: string) {
+    return (
+      MULTI_VALUE_ALLOWED.includes(name.toLowerCase()) ||
+      value.indexOf(JOIN_MARKER) > 0
+    );
+  }
+
   getMultiple(name: string): string[] | undefined {
     const value = super.get(name);
     if (!value) {
       return undefined;
     }
-    if (MULTI_VALUE_ALLOWED.includes(name.toLowerCase())) {
+    if (this.isMultiValue(name, value)) {
       return value.split(JOIN_MARKER);
     }
     return [value];
   }
 
   append(name: string, value: string) {
-    if (MULTI_VALUE_ALLOWED.includes(name.toLowerCase())) {
-      const prev = this.get(name);
-      this.set(name, prev !== undefined ? prev + JOIN_MARKER + value : value);
+    const prev = this.get(name);
+    if (prev) {
+      this.set(name, prev + JOIN_MARKER + value);
     } else {
       this.set(name, value);
     }
@@ -368,7 +372,7 @@ export class HeadersMultiMap extends Map<string, string> {
 
   override *[Symbol.iterator](): IterableIterator<[string, string]> {
     for (const [name, value] of super[Symbol.iterator]()) {
-      if (MULTI_VALUE_ALLOWED.includes(name.toLowerCase())) {
+      if (this.isMultiValue(name, value)) {
         for (const v of value.split(JOIN_MARKER)) {
           yield [name, v];
         }

--- a/test/testSerializer.test.ts
+++ b/test/testSerializer.test.ts
@@ -637,6 +637,64 @@ Content-Security-Policy: script-src 'self'\r\n\
     );
   });
 
+  test("create record with multiple header value as combined dict", async () => {
+    const url = "https://example.com/";
+    const date = "2000-01-01T00:00:00Z";
+    const type = "request";
+    const warcHeaders = {
+      "WARC-Record-ID": "<urn:uuid:12345678-feb0-11e6-8f83-68a86d1772ce>",
+      "WARC-Protocol": multiValueHeader("WARC-Protocol", ["h2", "tls/1.0"]),
+    };
+    const httpHeaders = {
+      "Content-Security-Policy": multiValueHeader("Content-Security-Policy", [
+        "image-src 'self'",
+        "frame-src 'self'",
+        "script-src 'self'",
+      ]),
+    };
+
+    const statusline = "GET /file HTTP/1.1";
+
+    const record = await WARCRecord.create({
+      url,
+      date,
+      type,
+      warcHeaders,
+      httpHeaders,
+      statusline,
+      keepHeadersCase: true,
+    });
+
+    expect(record.warcType).toBe("request");
+
+    const gzipped = await WARCSerializer.serialize(record, { gzip: true });
+    const res = decoder.decode(pako.inflate(gzipped));
+
+    expect(res).toBe(
+      "\
+WARC/1.0\r\n\
+WARC-Record-ID: <urn:uuid:12345678-feb0-11e6-8f83-68a86d1772ce>\r\n\
+WARC-Protocol: h2\r\n\
+WARC-Protocol: tls/1.0\r\n\
+WARC-Target-URI: https://example.com/\r\n\
+WARC-Date: 2000-01-01T00:00:00Z\r\n\
+WARC-Type: request\r\n\
+Content-Type: application/http; msgtype=request\r\n\
+WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\r\n\
+WARC-Block-Digest: sha256:97e0b14dc2509c7e082aa1cec8f2075a6478dbbf03727403fcc40c6988a16118\r\n\
+Content-Length: 152\r\n\
+\r\n\
+GET /file HTTP/1.1\r\n\
+Content-Security-Policy: image-src 'self'\r\n\
+Content-Security-Policy: frame-src 'self'\r\n\
+Content-Security-Policy: script-src 'self'\r\n\
+\r\n\
+\r\n\
+\r\n\
+",
+    );
+  });
+
   test("create warcinfo", async () => {
     const filename = "/my/web/archive.warc";
     const type = "warcinfo";

--- a/test/testSerializer.test.ts
+++ b/test/testSerializer.test.ts
@@ -580,6 +580,63 @@ set-cookie: greeting=hello, name=world\r\n\
     }
   });
 
+  test("create record with multiple header value", async () => {
+    const url = "https://example.com/";
+    const date = "2000-01-01T00:00:00Z";
+    const type = "request";
+    const warcHeaders = {
+      "WARC-Record-ID": "<urn:uuid:12345678-feb0-11e6-8f83-68a86d1772ce>",
+      "WARC-Protocol": multiValueHeader("WARC-Protocol", ["h2", "tls/1.0"]),
+    };
+    const httpHeaders: [string, string][] = [
+      // other header repeated multiple times
+      ["Content-Security-Policy", "image-src 'self'"],
+      ["Content-Security-Policy", "frame-src 'self'"],
+      ["Content-Security-Policy", "script-src 'self'"],
+    ];
+
+    const statusline = "GET /file HTTP/1.1";
+
+    const record = await WARCRecord.create({
+      url,
+      date,
+      type,
+      warcHeaders,
+      httpHeaders,
+      statusline,
+      keepHeadersCase: true,
+    });
+
+    expect(record.warcType).toBe("request");
+
+    const gzipped = await WARCSerializer.serialize(record, { gzip: true });
+    const res = decoder.decode(pako.inflate(gzipped));
+
+    expect(res).toBe(
+      "\
+WARC/1.0\r\n\
+WARC-Record-ID: <urn:uuid:12345678-feb0-11e6-8f83-68a86d1772ce>\r\n\
+WARC-Protocol: h2\r\n\
+WARC-Protocol: tls/1.0\r\n\
+WARC-Target-URI: https://example.com/\r\n\
+WARC-Date: 2000-01-01T00:00:00Z\r\n\
+WARC-Type: request\r\n\
+Content-Type: application/http; msgtype=request\r\n\
+WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\r\n\
+WARC-Block-Digest: sha256:97e0b14dc2509c7e082aa1cec8f2075a6478dbbf03727403fcc40c6988a16118\r\n\
+Content-Length: 152\r\n\
+\r\n\
+GET /file HTTP/1.1\r\n\
+Content-Security-Policy: image-src 'self'\r\n\
+Content-Security-Policy: frame-src 'self'\r\n\
+Content-Security-Policy: script-src 'self'\r\n\
+\r\n\
+\r\n\
+\r\n\
+",
+    );
+  });
+
   test("create warcinfo", async () => {
     const filename = "/my/web/archive.warc";
     const type = "warcinfo";


### PR DESCRIPTION
- don't throw error on unexpected multi-value headers
- fix append() in HeadersMultiMap() to store multiple value for any headers

bump to 2.4.8