### PR TITLE
better multi-value header validation:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "warcio",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "keywords": [
     "WARC",
     "web archiving"

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -312,17 +312,41 @@ export function latin1ToUTF(str: string) {
 
 // ===========================================================================
 // headers multi map
-const MULTI_VALUE_ALLOWED = [
-  "set-cookie",
+const WARC_MULTI_VALUE_ALLOWED = [
   "warc-concurrent-to",
   "warc-protocol",
 ];
+
+const HTTP_MULTI_VALUE_DISALLOW = [
+  "content-length",
+  "content-type",
+  "authorization",
+  "proxy-authorization",
+  "referer",
+  "user-agent",
+  "strict-transport-security"
+]
 
 // using something other than comma to reduce change of any collisions with actual data
 // in theory, collision still possible with arbitrary cookie value
 const JOIN_MARKER = ",,,";
 
+export function isValidMultiValueHeaderName(name: string) {
+  const nameLower = name.toLowerCase();
+  if (nameLower.startsWith("warc-")) {
+    if (!WARC_MULTI_VALUE_ALLOWED.includes(nameLower)) {
+      throw new Error("Invalid multi value WARC header: " + name);
+    }
+  } else if (HTTP_MULTI_VALUE_DISALLOW.includes(nameLower)) {
+    throw new Error("Invalid multi value HTTP header: " + name);
+  }
+
+  return true;
+}
+
 export function multiValueHeader(name: string, value: string[]) {
+  isValidMultiValueHeaderName(name);
+
   return value.join(JOIN_MARKER);
 }
 
@@ -344,10 +368,7 @@ export class HeadersMultiMap extends Map<string, string> {
   }
 
   isMultiValue(name: string, value: string) {
-    return (
-      MULTI_VALUE_ALLOWED.includes(name.toLowerCase()) ||
-      value.indexOf(JOIN_MARKER) > 0
-    );
+    return value.indexOf(JOIN_MARKER) > 0 && isValidMultiValueHeaderName(name);
   }
 
   getMultiple(name: string): string[] | undefined {
@@ -364,6 +385,7 @@ export class HeadersMultiMap extends Map<string, string> {
   append(name: string, value: string) {
     const prev = this.get(name);
     if (prev) {
+      isValidMultiValueHeaderName(name);
       this.set(name, prev + JOIN_MARKER + value);
     } else {
       this.set(name, value);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -312,20 +312,10 @@ export function latin1ToUTF(str: string) {
 
 // ===========================================================================
 // headers multi map
-const WARC_MULTI_VALUE_ALLOWED = [
+export const WARC_ALLOWED_MULTI_VALUE_HEADERS = [
   "warc-concurrent-to",
   "warc-protocol",
 ];
-
-const HTTP_MULTI_VALUE_DISALLOW = [
-  "content-length",
-  "content-type",
-  "authorization",
-  "proxy-authorization",
-  "referer",
-  "user-agent",
-  "strict-transport-security"
-]
 
 // using something other than comma to reduce change of any collisions with actual data
 // in theory, collision still possible with arbitrary cookie value
@@ -334,11 +324,9 @@ const JOIN_MARKER = ",,,";
 export function isValidMultiValueHeaderName(name: string) {
   const nameLower = name.toLowerCase();
   if (nameLower.startsWith("warc-")) {
-    if (!WARC_MULTI_VALUE_ALLOWED.includes(nameLower)) {
+    if (!WARC_ALLOWED_MULTI_VALUE_HEADERS.includes(nameLower)) {
       throw new Error("Invalid multi value WARC header: " + name);
     }
-  } else if (HTTP_MULTI_VALUE_DISALLOW.includes(nameLower)) {
-    throw new Error("Invalid multi value HTTP header: " + name);
   }
 
   return true;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,4 +8,5 @@ export {
   mfdToQueryString,
   concatChunks,
   splitChunk,
+  WARC_ALLOWED_MULTI_VALUE_HEADERS,
 } from "./lib/utils";

--- a/test/testSerializer.test.ts
+++ b/test/testSerializer.test.ts
@@ -637,6 +637,26 @@ Content-Security-Policy: script-src 'self'\r\n\
     );
   });
 
+  test("invalid multi-value headers", () => {
+    const invalidWarcHeaders = () => {
+      return {
+        "WARC-Record-ID": "<urn:uuid:12345678-feb0-11e6-8f83-68a86d1772ce>",
+        "WARC-Type": multiValueHeader("WARC-Type", ["response", "request"]),
+      }
+    };
+
+    expect(invalidWarcHeaders).toThrow("Invalid multi value WARC header: WARC-Type");
+
+    const invalidHttpHeaders = () => {
+      return {
+        "Custom": multiValueHeader("Custom", ["A", "B"]),
+        "Content-Length": multiValueHeader("Content-Length", ["123", "456"]),
+      }
+    };
+
+    expect(invalidHttpHeaders).toThrow("Invalid multi value HTTP header: Content-Length");
+  });
+
   test("create record with multiple header value as combined dict", async () => {
     const url = "https://example.com/";
     const date = "2000-01-01T00:00:00Z";

--- a/test/testSerializer.test.ts
+++ b/test/testSerializer.test.ts
@@ -642,19 +642,22 @@ Content-Security-Policy: script-src 'self'\r\n\
       return {
         "WARC-Record-ID": "<urn:uuid:12345678-feb0-11e6-8f83-68a86d1772ce>",
         "WARC-Type": multiValueHeader("WARC-Type", ["response", "request"]),
-      }
+      };
     };
 
-    expect(invalidWarcHeaders).toThrow("Invalid multi value WARC header: WARC-Type");
+    expect(invalidWarcHeaders).toThrow(
+      "Invalid multi value WARC header: WARC-Type",
+    );
 
     const invalidHttpHeaders = () => {
       return {
-        "Custom": multiValueHeader("Custom", ["A", "B"]),
+        Custom: multiValueHeader("Custom", ["A", "B"]),
         "Content-Length": multiValueHeader("Content-Length", ["123", "456"]),
-      }
+      };
     };
 
-    expect(invalidHttpHeaders).toThrow("Invalid multi value HTTP header: Content-Length");
+    // invalid multi-value HTTP headers are allowed
+    expect(invalidHttpHeaders).not.toThrow();
   });
 
   test("create record with multiple header value as combined dict", async () => {


### PR DESCRIPTION
- allow only certain WARC headers to be multi-value
- disallow certain HTTP headers to be multi-value, allow others by default
- bump to 2.4.9