### PR TITLE
Limit query size to 4K length

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "warcio",
-  "version": "2.4.9",
+  "version": "2.4.10",
   "keywords": [
     "WARC",
     "web archiving"

--- a/src/lib/indexer.ts
+++ b/src/lib/indexer.ts
@@ -12,7 +12,7 @@ import {
 
 export const DEFAULT_FIELDS = ["offset", "warc-type", "warc-target-uri"];
 
-export const DEFAULT_MAX_QUERY_SIZE = 8192;
+export const DEFAULT_MAX_QUERY_SIZE = 4096;
 
 // ===========================================================================
 abstract class BaseIndexer {

--- a/src/lib/indexer.ts
+++ b/src/lib/indexer.ts
@@ -12,6 +12,8 @@ import {
 
 export const DEFAULT_FIELDS = ["offset", "warc-type", "warc-target-uri"];
 
+export const DEFAULT_MAX_QUERY_SIZE = 8192;
+
 // ===========================================================================
 abstract class BaseIndexer {
   opts: Partial<IndexCommandArgs>;
@@ -313,6 +315,7 @@ export class CDXIndexer extends Indexer {
     reqRecord: WARCRecord | null,
     indexOffset: IndexerOffsetLength,
     filename: string,
+    maxQuerySize = DEFAULT_MAX_QUERY_SIZE,
   ) {
     let method;
     let requestBody;
@@ -329,7 +332,7 @@ export class CDXIndexer extends Indexer {
 
       method = request.method;
 
-      if (postToGetUrl(request)) {
+      if (postToGetUrl(request, maxQuerySize)) {
         requestBody = request.requestBody;
         url = request.url;
       }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -55,7 +55,7 @@ export function getSurt(url: string) {
   }
 }
 
-export function postToGetUrl(request: Request) {
+export function postToGetUrl(request: Request, maxQuerySize = 0) {
   const { method, headers, postData = "" } = request;
 
   if (method === "GET") {
@@ -130,6 +130,10 @@ export function postToGetUrl(request: Request) {
     } catch (_) {
       // just clear out invalid query string
       query = "";
+    }
+
+    if (maxQuerySize > 0 && query.length > maxQuerySize) {
+      query = query.slice(0, maxQuerySize);
     }
 
     request.url = appendRequestQuery(request.url, query, request.method);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -124,16 +124,16 @@ export function postToGetUrl(request: Request, maxQuerySize = 0) {
   }
 
   if (query != null) {
+    if (maxQuerySize > 0 && query.length > maxQuerySize) {
+      query = query.slice(0, maxQuerySize);
+    }
+
     request.requestBody = query;
     try {
       query = decodeURI(query);
     } catch (_) {
       // just clear out invalid query string
       query = "";
-    }
-
-    if (maxQuerySize > 0 && query.length > maxQuerySize) {
-      query = query.slice(0, maxQuerySize);
     }
 
     request.url = appendRequestQuery(request.url, query, request.method);


### PR DESCRIPTION
Avoid extremely long POST request bodies. Set limit to 4K, to match cdxj-indexer
Allow overriding if needed.
bump to 2.4.10